### PR TITLE
Update deprecated github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup Go environment
-        uses: actions/setup-go@v2.1.3
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           # The Go version to download (if necessary) and use. Supports semver spec and ranges.
           go-version: 1.18
@@ -42,7 +42,7 @@ jobs:
         run: go test -coverprofile cover.out -v ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
 
       - name: Check typescript model generation
         run: bash ./build/typescript-model/generate.sh

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           persist-credentials: false
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: 1.17
       - name: Run tests
         run: go test ./... -coverprofile cover.out
       - name: Codecov
-        uses: codecov/codecov-action@v2.1.0
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4

--- a/.github/workflows/publish-devfile-schema.yaml
+++ b/.github/workflows/publish-devfile-schema.yaml
@@ -20,14 +20,14 @@ jobs:
           python-version: '3.9'
 
       - name: Checkout devfile/devfile-web
-        uses: actions/checkout@v2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           repository: devfile/devfile-web
           persist-credentials: false
           path: devfile-web-repo
 
       - name: Checkout devfile api
-        uses: actions/checkout@v2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           path: api-repo
 

--- a/.github/workflows/release-devfile-schema.yaml
+++ b/.github/workflows/release-devfile-schema.yaml
@@ -20,14 +20,14 @@ jobs:
           python-version: '3.9'
 
       - name: Checkout devfile/devfile-web
-        uses: actions/checkout@v2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           repository: devfile/devfile-web
           persist-credentials: false
           path: devfile-web-repo
 
       - name: Checkout devfile/api
-        uses: actions/checkout@v2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           path: api-repo
 

--- a/.github/workflows/release-typescript-models.yaml
+++ b/.github/workflows/release-typescript-models.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout devfile/api
-        uses: actions/checkout@v2
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           path: api
 


### PR DESCRIPTION
## What does this PR do?

This PR updates all deprecated github actions using NodeJS 12 in order to use NodeJS 16. The list of actions updated are:

- `actions/checkout@v2` > `actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3`
- `actions/setup-go@v2` > `actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0`
- `codecov/codecov-action@2.1.0` > `codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4`

### Which issue(s) does this PR fix

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
