### PR TITLE
Update setup-node action to latest version

### DIFF
--- a/.github/workflows/release-typescript-models.yaml
+++ b/.github/workflows/release-typescript-models.yaml
@@ -46,7 +46,7 @@ jobs:
           path: 'api/build/typescript-model/requirements.txt'
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
         with:
           node-version: 12
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## What does this PR do?

Updates the `setup-node` github action to latest version `v4.0.0` as the current one is fairly old (`v1`). This could also be a potential workaround on the `yarn build` failure we are facing here: https://github.com/devfile/api/actions/runs/6800556145/job/18489362623

### Which issue(s) does this PR fix

fixes  #

### PR acceptance criteria

Testing and documentation do not need to be complete in order for this PR to be approved. We just need to ensure tracking issues are opened.

> - Open new test/doc issues under the [devfile/api](https://github.com/devfile/api/issues) repo
> - Check each criteria if:
> - There is a separate tracking issue. Add the issue link under the criteria
>  **or**
> - test/doc updates are made as part of this PR
> - If unchecked, explain why it's not needed

- [ ] Unit/Functional tests

  <!-- _These are run as part of the PR workflow, ensure they are updated_ -->

- [ ] [QE Integration test](https://github.com/devfile/integration-tests)

  <!--  _Do we need to verify integration with ODO and Openshift console?_ -->

- [ ] Documentation

   <!-- _This includes product docs and READMEs._ -->

- [ ] Client Impact

  <!-- _Do we have anything that can break our clients?  If so, open a notifying issue_ -->

### How to test changes / Special notes to the reviewer
